### PR TITLE
Improve student activity registration system

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/README.md
+++ b/src/README.md
@@ -6,6 +6,7 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 - View all available extracurricular activities
 - Sign up for activities
+- Unregister participants from activities
 
 ## Getting Started
 
@@ -29,8 +30,10 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 | Method | Endpoint                                                          | Description                                                         |
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
+| GET    | `/`                                                               | Redirect to the static frontend page                                |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
 | POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| DELETE | `/activities/{activity_name}/signup?email=student@mergington.edu` | Unregister a participant from an activity                           |
 
 ## Data Model
 

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Basketball Team": {
+        "description": "Join the school basketball team and compete in tournaments",
+        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 15,
+        "participants": []
+    },
+    "Swimming Club": {
+        "description": "Improve swimming skills and participate in swim meets",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 20,
+        "participants": []
+    },
+    "Drama Club": {
+        "description": "Explore theater arts and perform in school productions",
+        "schedule": "Wednesdays, 3:30 PM - 5:30 PM",
+        "max_participants": 25,
+        "participants": []
+    },
+    "Art Studio": {
+        "description": "Develop artistic skills in painting, drawing, and sculpture",
+        "schedule": "Fridays, 3:00 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": []
+    },
+    "Debate Team": {
+        "description": "Develop critical thinking and public speaking through competitive debates",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 18,
+        "participants": []
+    },
+    "Science Olympiad": {
+        "description": "Compete in science competitions and conduct research projects",
+        "schedule": "Tuesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 16,
+        "participants": []
     }
 }
 
@@ -61,6 +97,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student is already signed up")
 
     # Add student
     activity["participants"].append(email)

--- a/src/app.py
+++ b/src/app.py
@@ -105,3 +105,22 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/signup")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    # Validate activity exists
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    # Get the specific activity
+    activity = activities[activity_name]
+
+    # Validate student is signed up
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=404, detail="Participant not found in this activity")
+
+    # Remove student
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -4,6 +4,25 @@ document.addEventListener("DOMContentLoaded", () => {
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
 
+  function escapeHtml(value) {
+    return value
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#39;");
+  }
+
+  function showMessage(text, type) {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
@@ -12,6 +31,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -19,12 +39,39 @@ document.addEventListener("DOMContentLoaded", () => {
         activityCard.className = "activity-card";
 
         const spotsLeft = details.max_participants - details.participants.length;
+        const participantsListMarkup = details.participants.length
+          ? details.participants
+              .map(
+                (participant) => `
+                  <li class="participant-item">
+                    <span class="participant-email">${escapeHtml(participant)}</span>
+                    <button
+                      type="button"
+                      class="delete-participant-btn"
+                      data-activity="${encodeURIComponent(name)}"
+                      data-email="${encodeURIComponent(participant)}"
+                      aria-label="Unregister ${escapeHtml(participant)}"
+                      title="Unregister participant"
+                    >
+                      &#128465;
+                    </button>
+                  </li>
+                `
+              )
+              .join("")
+          : "<li class=\"empty-state\">No participants yet</li>";
 
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <p class="participants-title"><strong>Participants:</strong></p>
+            <ul class="participants-list">
+              ${participantsListMarkup}
+            </ul>
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);
@@ -59,25 +106,46 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         signupForm.reset();
+        fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
+    }
+  });
+
+  activitiesList.addEventListener("click", async (event) => {
+    const deleteButton = event.target.closest(".delete-participant-btn");
+    if (!deleteButton) {
+      return;
+    }
+
+    const activity = decodeURIComponent(deleteButton.dataset.activity);
+    const email = decodeURIComponent(deleteButton.dataset.email);
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activity)}/signup?email=${encodeURIComponent(email)}`,
+        {
+          method: "DELETE",
+        }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        showMessage(result.message, "success");
+        fetchActivities();
+      } else {
+        showMessage(result.detail || "Failed to unregister participant.", "error");
+      }
+    } catch (error) {
+      showMessage("Failed to unregister participant. Please try again.", "error");
+      console.error("Error unregistering participant:", error);
     }
   });
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,62 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px dashed #d7def7;
+}
+
+.participants-title {
+  margin-bottom: 8px;
+  color: #1a237e;
+}
+
+.participants-list {
+  margin: 0;
+  padding-left: 0;
+  list-style: none;
+}
+
+.participants-list li {
+  margin-bottom: 8px;
+  color: #2f3c59;
+}
+
+.participant-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  background-color: #ffffff;
+  border: 1px solid #e4e9fb;
+  border-radius: 8px;
+  padding: 6px 10px;
+}
+
+.participant-email {
+  overflow-wrap: anywhere;
+}
+
+.delete-participant-btn {
+  background-color: transparent;
+  border: 1px solid #f4c6c6;
+  color: #c62828;
+  padding: 4px 7px;
+  border-radius: 6px;
+  line-height: 1;
+  font-size: 14px;
+}
+
+.delete-participant-btn:hover {
+  background-color: #ffebee;
+}
+
+.participants-list li.empty-state {
+  font-style: italic;
+  color: #6c757d;
+}
+
 .form-group {
   margin-bottom: 15px;
 }
@@ -112,6 +168,10 @@ button:hover {
   margin-top: 20px;
   padding: 10px;
   border-radius: 4px;
+}
+
+#message {
+  margin-top: 18px;
 }
 
 .success {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+from copy import deepcopy
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.app import activities, app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_activities_state():
+    original_state = deepcopy(activities)
+    try:
+        yield
+    finally:
+        activities.clear()
+        activities.update(deepcopy(original_state))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,92 @@
+from urllib.parse import quote
+
+from src.app import activities
+
+
+def test_root_redirects_to_static_index(client):
+    response = client.get("/", follow_redirects=False)
+
+    assert response.status_code in (302, 307)
+    assert response.headers["location"] == "/static/index.html"
+
+
+def test_get_activities_returns_activity_data(client):
+    response = client.get("/activities")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, dict)
+    assert "Chess Club" in data
+    assert "participants" in data["Chess Club"]
+
+
+def test_signup_successfully_adds_participant(client):
+    email = "newstudent@mergington.edu"
+    activity_name = "Chess Club"
+
+    response = client.post(
+        f"/activities/{quote(activity_name, safe='')}/signup",
+        params={"email": email},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["message"] == f"Signed up {email} for {activity_name}"
+    assert email in activities[activity_name]["participants"]
+
+
+def test_signup_returns_404_for_unknown_activity(client):
+    response = client.post(
+        f"/activities/{quote('Unknown Club', safe='')}/signup",
+        params={"email": "student@mergington.edu"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_signup_returns_400_for_duplicate_participant(client):
+    email = "michael@mergington.edu"
+    activity_name = "Chess Club"
+
+    response = client.post(
+        f"/activities/{quote(activity_name, safe='')}/signup",
+        params={"email": email},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Student is already signed up"
+
+
+def test_unregister_successfully_removes_participant(client):
+    email = "michael@mergington.edu"
+    activity_name = "Chess Club"
+
+    response = client.delete(
+        f"/activities/{quote(activity_name, safe='')}/signup",
+        params={"email": email},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["message"] == f"Unregistered {email} from {activity_name}"
+    assert email not in activities[activity_name]["participants"]
+
+
+def test_unregister_returns_404_for_unknown_activity(client):
+    response = client.delete(
+        f"/activities/{quote('Unknown Club', safe='')}/signup",
+        params={"email": "student@mergington.edu"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_unregister_returns_404_for_missing_participant(client):
+    activity_name = "Chess Club"
+    response = client.delete(
+        f"/activities/{quote(activity_name, safe='')}/signup",
+        params={"email": "not-registered@mergington.edu"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Participant not found in this activity"


### PR DESCRIPTION
This pull request adds a complete "unregister participant" feature to the FastAPI extracurricular activities app, including backend API support, frontend integration, improved participant display, and comprehensive test coverage. It also introduces new activities to the dataset and improves the development setup.

**Backend API enhancements:**

* Added a `DELETE /activities/{activity_name}/signup?email=` endpoint to allow participants to unregister from activities, with proper error handling for unknown activities and missing participants.
* Expanded the initial activities dataset in `src/app.py` to include several new clubs and teams, each with their own details and participant lists.

**Frontend improvements:**

* Updated `src/static/app.js` to display participants for each activity, including a delete button for unregistering, and improved error/success messaging using a new `showMessage` helper. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R34-R74) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3L62-R148)
* Enhanced participant list styling in `src/static/styles.css` for better clarity and usability, including styles for the participant section, delete button, and message display. [[1]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R77-R132) [[2]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R173-R176)

**Testing and development setup:**

* Added a full test suite in `tests/test_app.py` to cover registration, unregistration, and error cases for the API endpoints.
* Introduced a pytest fixture in `tests/conftest.py` to reset the activities state between tests, ensuring test isolation.
* Added VSCode settings in `.vscode/settings.json` to enable pytest for easier local development and testing.

**Documentation updates:**

* Updated `src/README.md` to document the new unregister feature and API endpoint, and clarified the root redirect behavior. [[1]](diffhunk://#diff-e1d5879ce3e222eb0cdd43051fb8c34c00796467acb091d0b3fa939ee3355cb5R9) [[2]](diffhunk://#diff-e1d5879ce3e222eb0cdd43051fb8c34c00796467acb091d0b3fa939ee3355cb5R33-R36)